### PR TITLE
Refine calculator with tip input and city averages

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,13 +140,36 @@
           Дней в неделю: <span id="daysValue" class="calc-value">5</span>
           <input type="range" id="daysRange" min="1" max="7" value="5" step="1" aria-label="Дни в неделю">
         </label>
-        <p class="calc-note">* Это примерный порядок цифр, он зависит от спроса, времени суток и бонусов.</p>
+        <label class="calc-label">
+          Средние чаевые за смену, ₽
+          <input type="number" id="tipsInput" min="0" step="50" value="250" inputmode="numeric" aria-label="Средние чаевые за смену">
+          <span class="calc-help">Сумма, которую обычно оставляют клиенты поверх тарифа.</span>
+        </label>
+        <label class="calc-label">
+          Ежедневные расходы, ₽
+          <input type="number" id="expensesInput" min="0" step="50" value="150" inputmode="numeric" aria-label="Ежедневные расходы">
+          <span class="calc-help">Транспорт, связь, амортизация оборудования.</span>
+        </label>
+        <p class="calc-note">* Это примерный порядок цифр, он зависит от спроса, времени суток и чаевых.</p>
         <p class="calc-hint" id="calcHint" aria-live="polite"></p>
+        <p class="city-average" id="cityAverage" aria-live="polite"></p>
       </div>
       <div class="calc-result">
-        <div class="result-card"><div>День</div><strong id="dayIncome">—</strong></div>
-        <div class="result-card"><div>Неделя</div><strong id="weekIncome">—</strong></div>
-        <div class="result-card"><div>Месяц ~</div><strong id="monthIncome">—</strong></div>
+        <div class="result-card">
+          <div>День</div>
+          <strong id="dayIncome">—</strong>
+          <span class="result-sub" id="dayIncomeNet">Чистыми —</span>
+        </div>
+        <div class="result-card">
+          <div>Неделя</div>
+          <strong id="weekIncome">—</strong>
+          <span class="result-sub" id="weekIncomeNet">Чистыми —</span>
+        </div>
+        <div class="result-card">
+          <div>Месяц ~</div>
+          <strong id="monthIncome">—</strong>
+          <span class="result-sub" id="monthIncomeNet">Чистыми —</span>
+        </div>
         <a class="btn btn-primary btn-wide" data-role="apply-cta" href="https://ya.cc/t/-yGszGNW7iYQXz" target="_blank" rel="noopener">Стать курьером</a>
       </div>
     </div>

--- a/style.css
+++ b/style.css
@@ -154,6 +154,8 @@ body{
 /* hints */
 .calc-hint{margin-top:6px;color:#333;font-size:14px}
 .theme-dark .calc-hint{color:#ddd}
+.city-average{margin-top:8px;font-size:14px;color:#444;font-weight:500;line-height:1.5}
+.theme-dark .city-average{color:#ccc}
 
 .test p{line-height:1.6}
 
@@ -258,6 +260,22 @@ body{
   font-size:14px;
   color:#000;
 }
+.calc-label input[type="number"]{
+  margin-top:6px;
+  padding:8px 10px;
+  border:1px solid #d4d4d4;
+  border-radius:8px;
+  background:#fff;
+  font-size:14px;
+  color:#000;
+}
+.calc-help{
+  margin-top:4px;
+  font-weight:400;
+  font-size:12px;
+  color:#666;
+  line-height:1.4;
+}
 input[type="range"]{
   accent-color:var(--orange);
   height:4px;
@@ -361,6 +379,10 @@ input[type="range"]::-moz-range-thumb{
   font-size:20px;
   font-weight:700;
   color:var(--black);
+}
+.result-sub{
+  font-size:13px;
+  color:#777;
 }
 @media (max-width:600px){
   .calc-grid{


### PR DESCRIPTION
## Summary
- rename the per-shift bonus control to average tips with updated defaults and helper copy
- introduce city-level average earnings using predefined tip data and formatted currency helpers
- surface the city average readout in the calculator and add matching styles

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e11f3caa3c8327a0fed2319585f063