### PR TITLE
Use city tip averages in calculator

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,13 +140,57 @@
           Дней в неделю: <span id="daysValue" class="calc-value">5</span>
           <input type="range" id="daysRange" min="1" max="7" value="5" step="1" aria-label="Дни в неделю">
         </label>
-        <p class="calc-note">* Это примерный порядок цифр, он зависит от спроса, времени суток и бонусов.</p>
+        <label class="calc-label">
+          Ежедневные расходы, ₽
+          <input type="number" id="expensesInput" min="0" step="50" value="150" inputmode="numeric" aria-label="Ежедневные расходы">
+          <span class="calc-help">Транспорт, связь, амортизация оборудования.</span>
+        </label>
+        <p class="calc-help">В расчёте учтены средние чаевые по выбранному городу.</p>
+        <p class="calc-note">* Это примерный порядок цифр, он зависит от спроса, времени суток и чаевых.</p>
         <p class="calc-hint" id="calcHint" aria-live="polite"></p>
       </div>
       <div class="calc-result">
-        <div class="result-card"><div>День</div><strong id="dayIncome">—</strong></div>
-        <div class="result-card"><div>Неделя</div><strong id="weekIncome">—</strong></div>
-        <div class="result-card"><div>Месяц ~</div><strong id="monthIncome">—</strong></div>
+        <div class="calc-summary" id="personalSummary" aria-live="polite">
+          <h3 class="calc-summary-title">Ваш расчёт</h3>
+          <ul class="calc-summary-list">
+            <li>
+              <span>Смена</span>
+              <strong id="personalDayIncome">—</strong>
+              <span class="result-sub" id="personalDayNet">Чистыми —</span>
+            </li>
+            <li>
+              <span>Неделя</span>
+              <strong id="personalWeekIncome">—</strong>
+              <span class="result-sub" id="personalWeekNet">Чистыми —</span>
+            </li>
+            <li>
+              <span>Месяц ~</span>
+              <strong id="personalMonthIncome">—</strong>
+              <span class="result-sub" id="personalMonthNet">Чистыми —</span>
+            </li>
+          </ul>
+        </div>
+        <div class="calc-average-panel" id="cityAveragePanel" aria-live="polite">
+          <h3 class="calc-average-title" id="cityAverageTitle">Средний доход по городу</h3>
+          <div class="calc-average-grid">
+            <div class="result-card result-card--compact">
+              <div>Смена</div>
+              <strong id="cityAvgDay">—</strong>
+              <span class="result-sub" id="cityAvgDayNet">Чистыми —</span>
+            </div>
+            <div class="result-card result-card--compact">
+              <div>Неделя</div>
+              <strong id="cityAvgWeek">—</strong>
+              <span class="result-sub" id="cityAvgWeekNet">Чистыми —</span>
+            </div>
+            <div class="result-card result-card--compact">
+              <div>Месяц</div>
+              <strong id="cityAvgMonth">—</strong>
+              <span class="result-sub" id="cityAvgMonthNet">Чистыми —</span>
+            </div>
+          </div>
+          <p class="calc-average-note" id="cityAverageNote"></p>
+        </div>
         <a class="btn btn-primary btn-wide" data-role="apply-cta" href="https://ya.cc/t/-yGszGNW7iYQXz" target="_blank" rel="noopener">Стать курьером</a>
       </div>
     </div>

--- a/script.js
+++ b/script.js
@@ -80,6 +80,9 @@ document.addEventListener('DOMContentLoaded', function () {
 })();
 
 // ===== calc tips
+const MONTH_FACTOR = 4.33; // среднее количество недель в месяце
+const AVERAGE_SCHEDULE = { hours: 6, days: 5 };
+const AVERAGE_EXPENSES = 150;
 const MODE_TIPS = {
   walk: 'Пеший курьер — удобнее в центре и рядом с метро. Ставьте короткие слоты в час-пик.',
   bike: 'Велосипед — идеален для плотной застройки и парков. Проверьте подсветку/дождевик.',
@@ -91,13 +94,28 @@ function updateCalcHint(){
   const citySel = document.getElementById('citySelect');
   const modeSel = document.getElementById('modeSelect');
   const hint = document.getElementById('calcHint');
+  const hoursRange = document.getElementById('hoursRange');
+  const daysRange = document.getElementById('daysRange');
+  const expensesInput = document.getElementById('expensesInput');
   if(!(citySel && modeSel && hint)) return;
   const modeKey = modeSel.value || 'walk';
-  const city = citySel.value || 'вашем городе';
-  hint.textContent = (MODE_TIPS[modeKey] || '') + ' · ' + 'Совет для ' + city + ': начинайте в час-пик и следите за погодой — осенью спрос выше.';
+  const cityName = citySel.value || 'вашем городе';
+  const hours = hoursRange ? parseInt(hoursRange.value, 10) : 0;
+  const days = daysRange ? parseInt(daysRange.value, 10) : 0;
+  const city = CITY_DATA.find(c => c.name === citySel.value) || CITY_DATA[0];
+  const mode = MODE_OPTIONS.find(m => m.key === modeSel.value) || MODE_OPTIONS[0];
+  const expenses = expensesInput ? parseFloat(expensesInput.value) || 0 : 0;
+  const baseDaily = (mode?.hourlyRate || 0) * hours * (city?.multiplier || 1);
+  const cityTips = typeof city?.avgTips === 'number' ? city.avgTips : 0;
+  const dailyGross = baseDaily + cityTips;
+  const dailyNet = Math.max(dailyGross - expenses, 0);
+  const netValue = Math.round(dailyNet);
+  const hasSchedule = hours > 0 && days > 0 && !Number.isNaN(netValue);
+  const netText = hasSchedule ? ` · При ${hours} ч/день и ${days} дн/неделе ориентир ${netValue.toLocaleString('ru-RU')} ₽ чистыми с учётом средних чаевых.` : '';
+  hint.textContent = (MODE_TIPS[modeKey] || '') + ' · Совет для ' + cityName + ': начинайте в час-пик и следите за погодой — осенью спрос выше.' + netText;
 }
 document.addEventListener('input', (e)=>{
-  if(e.target && (e.target.id==='citySelect' || e.target.id==='modeSelect' || e.target.id==='hoursRange' || e.target.id==='daysRange')){
+  if(e.target && (e.target.id==='citySelect' || e.target.id==='modeSelect' || e.target.id==='hoursRange' || e.target.id==='daysRange' || e.target.id==='expensesInput')){
     updateCalcHint();
   }
 });
@@ -112,24 +130,23 @@ const MODE_OPTIONS = [
   { key: 'auto', label: 'Авто', hourlyRate: 550 }
 ];
 const CITY_DATA = [
-  { name: 'Москва', multiplier: 1.2 },
-  { name: 'Санкт‑Петербург', multiplier: 1.15 },
-  { name: 'Екатеринбург', multiplier: 1.1 },
-  { name: 'Новосибирск', multiplier: 1.05 },
-  { name: 'Казань', multiplier: 1.05 },
-  { name: 'Краснодар', multiplier: 1.05 },
-  { name: 'Нижний Новгород', multiplier: 1.0 },
-  { name: 'Ростов-на-Дону', multiplier: 1.0 },
-  { name: 'Самара', multiplier: 1.0 },
-  { name: 'Уфа', multiplier: 0.95 },
-  { name: 'Пермь', multiplier: 0.95 },
-  { name: 'Воронеж', multiplier: 0.95 },
-  { name: 'Челябинск', multiplier: 0.95 },
-  { name: 'Красноярск', multiplier: 0.9 },
-  { name: 'Омск', multiplier: 0.9 },
-  { name: 'Саратов', multiplier: 0.9 }
+  { name: 'Москва', multiplier: 1.2, avgTips: 320 },
+  { name: 'Санкт‑Петербург', multiplier: 1.15, avgTips: 300 },
+  { name: 'Екатеринбург', multiplier: 1.1, avgTips: 270 },
+  { name: 'Новосибирск', multiplier: 1.05, avgTips: 260 },
+  { name: 'Казань', multiplier: 1.05, avgTips: 250 },
+  { name: 'Краснодар', multiplier: 1.05, avgTips: 250 },
+  { name: 'Нижний Новгород', multiplier: 1.0, avgTips: 230 },
+  { name: 'Ростов-на-Дону', multiplier: 1.0, avgTips: 230 },
+  { name: 'Самара', multiplier: 1.0, avgTips: 220 },
+  { name: 'Уфа', multiplier: 0.95, avgTips: 210 },
+  { name: 'Пермь', multiplier: 0.95, avgTips: 210 },
+  { name: 'Воронеж', multiplier: 0.95, avgTips: 200 },
+  { name: 'Челябинск', multiplier: 0.95, avgTips: 200 },
+  { name: 'Красноярск', multiplier: 0.9, avgTips: 190 },
+  { name: 'Омск', multiplier: 0.9, avgTips: 190 },
+  { name: 'Саратов', multiplier: 0.9, avgTips: 180 }
 ];
-
 /**
  * Populate select options for city and mode, and set up event listeners
  */
@@ -140,9 +157,22 @@ function initCalculator() {
   const daysRange = document.getElementById('daysRange');
   const hoursValue = document.getElementById('hoursValue');
   const daysValue = document.getElementById('daysValue');
-  const dayIncome = document.getElementById('dayIncome');
-  const weekIncome = document.getElementById('weekIncome');
-  const monthIncome = document.getElementById('monthIncome');
+  const personalDayIncome = document.getElementById('personalDayIncome');
+  const personalWeekIncome = document.getElementById('personalWeekIncome');
+  const personalMonthIncome = document.getElementById('personalMonthIncome');
+  const personalDayNet = document.getElementById('personalDayNet');
+  const personalWeekNet = document.getElementById('personalWeekNet');
+  const personalMonthNet = document.getElementById('personalMonthNet');
+  const expensesInput = document.getElementById('expensesInput');
+  const cityAveragePanel = document.getElementById('cityAveragePanel');
+  const cityAverageTitle = document.getElementById('cityAverageTitle');
+  const cityAvgDay = document.getElementById('cityAvgDay');
+  const cityAvgWeek = document.getElementById('cityAvgWeek');
+  const cityAvgMonth = document.getElementById('cityAvgMonth');
+  const cityAvgDayNet = document.getElementById('cityAvgDayNet');
+  const cityAvgWeekNet = document.getElementById('cityAvgWeekNet');
+  const cityAvgMonthNet = document.getElementById('cityAvgMonthNet');
+  const cityAverageNote = document.getElementById('cityAverageNote');
 
   if (!citySelect || !modeSelect) return;
 
@@ -187,32 +217,82 @@ function initCalculator() {
     });
   }
 
+  function formatCurrency(value) {
+    return Math.round(value).toLocaleString('ru-RU') + ' ₽';
+  }
+
   // Compute and display incomes
   function updateIncome() {
     const hours = parseInt(hoursRange.value, 10);
     const days = parseInt(daysRange.value, 10);
     const city = CITY_DATA.find(c => c.name === citySelect.value) || CITY_DATA[0];
     const mode = MODE_OPTIONS.find(m => m.key === modeSelect.value) || MODE_OPTIONS[0];
-    const daily = mode.hourlyRate * hours * city.multiplier;
-    const weekly = daily * days;
-    const monthly = weekly * 4;
-    dayIncome.textContent = Math.round(daily).toLocaleString('ru-RU') + ' ₽';
-    weekIncome.textContent = Math.round(weekly).toLocaleString('ru-RU') + ' ₽';
-    monthIncome.textContent = Math.round(monthly).toLocaleString('ru-RU') + ' ₽';
+    const expenses = expensesInput ? parseFloat(expensesInput.value) || 0 : 0;
+    const cityTips = typeof city.avgTips === 'number' ? city.avgTips : 0;
+    const baseDaily = mode.hourlyRate * hours * city.multiplier;
+    const dailyGross = baseDaily + cityTips;
+    const weeklyGross = dailyGross * days;
+    const monthlyGross = weeklyGross * MONTH_FACTOR;
+    const dailyNet = Math.max(dailyGross - expenses, 0);
+    const weeklyNetValue = Math.max(dailyNet * days, 0);
+    const monthlyNetValue = weeklyNetValue * MONTH_FACTOR;
+    if (personalDayIncome) personalDayIncome.textContent = formatCurrency(dailyGross);
+    if (personalWeekIncome) personalWeekIncome.textContent = formatCurrency(weeklyGross);
+    if (personalMonthIncome) personalMonthIncome.textContent = formatCurrency(monthlyGross);
+    if (personalDayNet) personalDayNet.textContent = 'Чистыми ' + formatCurrency(dailyNet);
+    if (personalWeekNet) personalWeekNet.textContent = 'Чистыми ' + formatCurrency(weeklyNetValue);
+    if (personalMonthNet) personalMonthNet.textContent = 'Чистыми ' + formatCurrency(monthlyNetValue);
     hoursValue.textContent = hours;
     daysValue.textContent = days;
   }
 
+  function updateCityAverage() {
+    if (!cityAveragePanel) return;
+    const city = CITY_DATA.find(c => c.name === citySelect.value) || CITY_DATA[0];
+    const mode = MODE_OPTIONS.find(m => m.key === modeSelect.value) || MODE_OPTIONS[0];
+    if (!city || !mode) {
+      return;
+    }
+    const schedule = city.averageSchedule || AVERAGE_SCHEDULE;
+    const expenses = typeof city.avgExpenses === 'number' ? city.avgExpenses : AVERAGE_EXPENSES;
+    const tips = typeof city.avgTips === 'number' ? city.avgTips : 0;
+    const hours = schedule.hours || AVERAGE_SCHEDULE.hours;
+    const days = schedule.days || AVERAGE_SCHEDULE.days;
+    const baseDaily = (mode.hourlyRate || 0) * hours * (city.multiplier || 1);
+    const dailyGross = baseDaily + tips;
+    const weeklyGross = dailyGross * days;
+    const monthlyGross = weeklyGross * MONTH_FACTOR;
+    const dailyNet = Math.max(dailyGross - expenses, 0);
+    const weeklyNetValue = Math.max(dailyNet * days, 0);
+    const monthlyNetValue = weeklyNetValue * MONTH_FACTOR;
+
+    if (cityAverageTitle) {
+      cityAverageTitle.textContent = `Средний доход — ${city.name}`;
+    }
+    if (cityAvgDay) cityAvgDay.textContent = formatCurrency(dailyGross);
+    if (cityAvgWeek) cityAvgWeek.textContent = formatCurrency(weeklyGross);
+    if (cityAvgMonth) cityAvgMonth.textContent = formatCurrency(monthlyGross);
+    if (cityAvgDayNet) cityAvgDayNet.textContent = 'Чистыми ' + formatCurrency(dailyNet);
+    if (cityAvgWeekNet) cityAvgWeekNet.textContent = 'Чистыми ' + formatCurrency(weeklyNetValue);
+    if (cityAvgMonthNet) cityAvgMonthNet.textContent = 'Чистыми ' + formatCurrency(monthlyNetValue);
+    if (cityAverageNote) {
+      const modeLabel = mode.label ? `для режима «${mode.label}» ` : '';
+      cityAverageNote.textContent = `${modeLabel}при графике ~${hours} ч/день и ${days} смен в неделю, средних чаевых ${formatCurrency(tips)} и расходах ${formatCurrency(expenses)}.`;
+    }
+  }
+
   // Listen to changes
-  citySelect.addEventListener('change', () => { updateIncome(); updateCalcHint(); });
-  modeSelect.addEventListener('change', () => { updateActiveModeIcon(); updateIncome(); updateCalcHint(); });
+  citySelect.addEventListener('change', () => { updateIncome(); updateCalcHint(); updateCityAverage(); });
+  modeSelect.addEventListener('change', () => { updateActiveModeIcon(); updateIncome(); updateCalcHint(); updateCityAverage(); });
   hoursRange.addEventListener('input', updateIncome);
   daysRange.addEventListener('input', updateIncome);
+  expensesInput && expensesInput.addEventListener('input', updateIncome);
 
   // Initialize
   updateActiveModeIcon();
   updateIncome();
   updateCalcHint();
+  updateCityAverage();
 }
 
 // Initialize calculator on DOMContentLoaded

--- a/style.css
+++ b/style.css
@@ -154,6 +154,8 @@ body{
 /* hints */
 .calc-hint{margin-top:6px;color:#333;font-size:14px}
 .theme-dark .calc-hint{color:#ddd}
+.city-average{margin-top:8px;font-size:14px;color:#444;font-weight:500;line-height:1.5}
+.theme-dark .city-average{color:#ccc}
 
 .test p{line-height:1.6}
 
@@ -258,6 +260,22 @@ body{
   font-size:14px;
   color:#000;
 }
+.calc-label input[type="number"]{
+  margin-top:6px;
+  padding:8px 10px;
+  border:1px solid #d4d4d4;
+  border-radius:8px;
+  background:#fff;
+  font-size:14px;
+  color:#000;
+}
+.calc-help{
+  margin-top:4px;
+  font-weight:400;
+  font-size:12px;
+  color:#666;
+  line-height:1.4;
+}
 input[type="range"]{
   accent-color:var(--orange);
   height:4px;
@@ -338,9 +356,54 @@ input[type="range"]::-moz-range-thumb{
   box-shadow:0 8px 24px rgba(0,0,0,0.06);
   display:flex;
   flex-direction:column;
-  gap:12px;
+  gap:16px;
   align-items:stretch;
   justify-content:flex-start;
+}
+.calc-summary{
+  background:#fffef5;
+  border:1px solid #ffe08a;
+  border-radius:12px;
+  padding:14px 16px;
+  display:flex;
+  flex-direction:column;
+  gap:10px;
+}
+.calc-summary-title{
+  margin:0;
+  font-size:16px;
+  font-weight:700;
+  text-align:center;
+  color:var(--black);
+}
+.calc-summary-list{
+  list-style:none;
+  margin:0;
+  padding:0;
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+}
+.calc-summary-list li{
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+  text-align:center;
+  background:#fff;
+  border-radius:10px;
+  padding:10px 12px;
+  box-shadow:inset 0 0 0 1px rgba(255,224,138,0.35);
+}
+.calc-summary-list li span:first-child{
+  font-size:13px;
+  color:#555;
+  text-transform:uppercase;
+  letter-spacing:0.05em;
+}
+.calc-summary-list strong{
+  font-size:20px;
+  font-weight:700;
+  color:var(--black);
 }
 .result-card{
   background:#fffef5;
@@ -353,6 +416,10 @@ input[type="range"]::-moz-range-thumb{
   justify-content:center;
   gap:4px;
 }
+.result-card--compact{
+  background:#ffffff;
+  border-color:#d6e2ff;
+}
 .result-card div{
   font-size:14px;
   color:#555;
@@ -361,6 +428,39 @@ input[type="range"]::-moz-range-thumb{
   font-size:20px;
   font-weight:700;
   color:var(--black);
+}
+.result-sub{
+  font-size:13px;
+  color:#777;
+}
+.calc-average-panel{
+  margin-top:8px;
+  padding:16px;
+  border-radius:14px;
+  background:linear-gradient(135deg, #eef3ff 0%, #f9fbff 100%);
+  border:1px solid #d6e2ff;
+  display:flex;
+  flex-direction:column;
+  gap:14px;
+}
+.calc-average-title{
+  margin:0;
+  font-size:16px;
+  font-weight:700;
+  text-align:center;
+  color:var(--black);
+}
+.calc-average-grid{
+  display:grid;
+  grid-template-columns:repeat(auto-fit, minmax(140px, 1fr));
+  gap:12px;
+}
+.calc-average-note{
+  margin:0;
+  font-size:13px;
+  color:#556072;
+  line-height:1.5;
+  text-align:center;
 }
 @media (max-width:600px){
   .calc-grid{


### PR DESCRIPTION
## Summary
- remove the manual input for tips from the income calculator and clarify that averages are included automatically
- rely on per-city average tips when computing personal and city comparison incomes, updating hint text accordingly
- remove duplicate income cards by consolidating the personal results into a single summary while keeping the city average panel prominent

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68e11f3caa3c8327a0fed2319585f063