### PR TITLE
Add bottom cities list and update CTA alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,8 +39,6 @@
       <p class="hero-sub">Свободный график, ежедневные выплаты, поддержка на старте. Подходит студентам, родителям и всем, кто хочет честный доход.</p>
       <div class="hero-ctas">
         <a class="btn btn-primary" href="https://ya.cc/t/-yGszGNW7iYQXz" target="_blank">Стать курьером</a>
-        <!-- Убираем кнопку "Снаряжение"; единственный призыв к действию увеличивает конверсию -->
-        <a class="btn btn-outline" href="#steps">Быстрый старт</a>
       </div>
       <ul class="quick-stats">
         <li><strong>От 4 часов</strong><span>слоты в день</span></li>
@@ -317,6 +315,96 @@
         <h3 class="faq-head">Работа есть по всей России?</h3>
         <div class="faq-a open">Да, большинство крупных городов и агломераций. Если не видите свой город — оставьте заявку, подскажем ближайший вариант.</div>
       </div>
+    </div>
+  </div>
+</section>
+
+
+<!-- ===== CITIES LIST ===== -->
+<section class="section cities" aria-label="Города, где доступна работа курьером">
+  <div class="container">
+    <h2 class="section-title">Работа курьером доступна в городах</h2>
+    <p class="lead">Выбирайте удобный для вас населённый пункт — подключение доступно во многих регионах России.</p>
+    <div class="cities-grid" role="list">
+      <span class="city" role="listitem">Москва</span>
+      <span class="city" role="listitem">Санкт-Петербург</span>
+      <span class="city" role="listitem">Екатеринбург</span>
+      <span class="city" role="listitem">Новосибирск</span>
+      <span class="city" role="listitem">Казань</span>
+      <span class="city" role="listitem">Нижний Новгород</span>
+      <span class="city" role="listitem">Самара</span>
+      <span class="city" role="listitem">Уфа</span>
+      <span class="city" role="listitem">Красноярск</span>
+      <span class="city" role="listitem">Челябинск</span>
+      <span class="city" role="listitem">Омск</span>
+      <span class="city" role="listitem">Ростов-на-Дону</span>
+      <span class="city" role="listitem">Воронеж</span>
+      <span class="city" role="listitem">Пермь</span>
+      <span class="city" role="listitem">Волгоград</span>
+      <span class="city" role="listitem">Краснодар</span>
+      <span class="city" role="listitem">Саратов</span>
+      <span class="city" role="listitem">Тюмень</span>
+      <span class="city" role="listitem">Тольятти</span>
+      <span class="city" role="listitem">Ижевск</span>
+      <span class="city" role="listitem">Барнаул</span>
+      <span class="city" role="listitem">Ульяновск</span>
+      <span class="city" role="listitem">Иркутск</span>
+      <span class="city" role="listitem">Хабаровск</span>
+      <span class="city" role="listitem">Ярославль</span>
+      <span class="city" role="listitem">Владивосток</span>
+      <span class="city" role="listitem">Махачкала</span>
+      <span class="city" role="listitem">Томск</span>
+      <span class="city" role="listitem">Оренбург</span>
+      <span class="city" role="listitem">Кемерово</span>
+      <span class="city" role="listitem">Новокузнецк</span>
+      <span class="city" role="listitem">Рязань</span>
+      <span class="city" role="listitem">Астрахань</span>
+      <span class="city" role="listitem">Пенза</span>
+      <span class="city" role="listitem">Липецк</span>
+      <span class="city" role="listitem">Киров</span>
+      <span class="city" role="listitem">Чебоксары</span>
+      <span class="city" role="listitem">Тверь</span>
+      <span class="city" role="listitem">Калуга</span>
+      <span class="city" role="listitem">Белгород</span>
+      <span class="city" role="listitem">Сочи</span>
+      <span class="city" role="listitem">Ставрополь</span>
+      <span class="city" role="listitem">Тула</span>
+      <span class="city" role="listitem">Брянск</span>
+      <span class="city" role="listitem">Курск</span>
+      <span class="city" role="listitem">Архангельск</span>
+      <span class="city" role="listitem">Мурманск</span>
+      <span class="city" role="listitem">Псков</span>
+      <span class="city" role="listitem">Смоленск</span>
+      <span class="city" role="listitem">Вологда</span>
+      <span class="city" role="listitem">Калининград</span>
+      <span class="city" role="listitem">Кострома</span>
+      <span class="city" role="listitem">Иваново</span>
+      <span class="city" role="listitem">Якутск</span>
+      <span class="city" role="listitem">Сургут</span>
+      <span class="city" role="listitem">Набережные Челны</span>
+      <span class="city" role="listitem">Череповец</span>
+      <span class="city" role="listitem">Комсомольск-на-Амуре</span>
+      <span class="city" role="listitem">Березники</span>
+      <span class="city" role="listitem">Подольск</span>
+      <span class="city" role="listitem">Мытищи</span>
+      <span class="city" role="listitem">Химки</span>
+      <span class="city" role="listitem">Люберцы</span>
+      <span class="city" role="listitem">Королёв</span>
+      <span class="city" role="listitem">Домодедово</span>
+      <span class="city" role="listitem">Жуковский</span>
+      <span class="city" role="listitem">Пушкино</span>
+      <span class="city" role="listitem">Электросталь</span>
+      <span class="city" role="listitem">Балашиха</span>
+      <span class="city" role="listitem">Реутов</span>
+      <span class="city" role="listitem">Долгопрудный</span>
+      <span class="city" role="listitem">Коломна</span>
+      <span class="city" role="listitem">Серпухов</span>
+      <span class="city" role="listitem">Железнодорожный</span>
+      <span class="city" role="listitem">Клин</span>
+      <span class="city" role="listitem">Одинцово</span>
+      <span class="city" role="listitem">Дмитров</span>
+      <span class="city" role="listitem">Зеленоград</span>
+      <span class="city" role="listitem">Щёлково</span>
     </div>
   </div>
 </section>

--- a/style.css
+++ b/style.css
@@ -39,7 +39,7 @@ body{
 .hero-sub{font-size:20px; margin:0 0 20px; opacity:0.95; max-width:680px}
 
 /* CTAs */
-.btn{display:inline-block;padding:12px 20px;border-radius:10px;text-decoration:none;font-weight:700;transition:all .22s ease;cursor:pointer}
+.btn{display:inline-flex;align-items:center;justify-content:center;padding:12px 20px;border-radius:10px;text-decoration:none;font-weight:700;transition:all .22s ease;cursor:pointer;text-align:center;line-height:1.2}
 .btn-primary{background:var(--orange);color:#fff;box-shadow: 0 8px 24px rgba(255,102,0,0.16)}
 .btn-primary:hover{transform:translateY(-4px); box-shadow:0 18px 40px rgba(255,102,0,0.18)}
 .btn-outline{background:transparent;color:var(--white);border:2px solid rgba(255,255,255,0.18)}
@@ -58,6 +58,12 @@ body{
 .section{padding:56px 0}
 .section-title{font-size:28px;margin:0 0 18px;font-weight:700;text-align:center}
 .lead{max-width:920px;margin:0 auto 18px;font-size:17px;color:#1e1e1e;text-align:center}
+
+/* Cities */
+.section.cities{background:var(--muted)}
+.cities-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:12px;margin:28px auto 0;max-width:var(--max-width)}
+.cities-grid .city{background:#fff;border-radius:14px;box-shadow:var(--shadow);padding:12px 16px;font-weight:600;color:#1f1f1f;text-align:center;display:flex;align-items:center;justify-content:center;transition:transform .2s ease,box-shadow .2s ease;font-size:15px;letter-spacing:.1px}
+.cities-grid .city:hover{transform:translateY(-4px);box-shadow:0 14px 32px rgba(0,0,0,0.12)}
 
 /* FEATURES GRID */
 .grid-4{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:18px}


### PR DESCRIPTION
## Summary
- add a new cities section at the bottom of the landing page mirroring the partner site layout
- center button labels and streamline the hero call-to-action set by removing the duplicate "Быстрый старт" button

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e12d183b7c8327b78dfe245df30c95