### PR TITLE
Enhance hero backgrounds with imagery overlays

### DIFF
--- a/style.css
+++ b/style.css
@@ -28,8 +28,13 @@ body{
 
 /* HERO */
 .hero{position:relative;color:var(--white);padding:48px 0;
-  background: linear-gradient(180deg, rgba(0,0,0,0.45), rgba(0,0,0,0.55)), #111;
-  min-height:520px;display:flex;align-items:center}
+  background:
+    linear-gradient(180deg, rgba(0,0,0,0.45), rgba(0,0,0,0.6)),
+    url('images/background.png');
+  background-size:cover;
+  background-position:center;
+  background-repeat:no-repeat;
+  min-height:520px;display:flex;align-items:center;overflow:hidden}
 .hero.small{min-height:240px;padding:36px 0}
 .hero-inner{display:flex;align-items:center;justify-content:space-between;gap:24px;width:100%}
 .hero-left{flex:1 1 560px; text-align:left}
@@ -52,6 +57,8 @@ body{
 .quick-stats span{font-size:13px;opacity:0.9}
 
 /* HERO RIGHT PREVIEW */
+.hero-overlay{position:absolute;inset:0;background:linear-gradient(180deg,rgba(0,0,0,0.45) 0%,rgba(0,0,0,0.75) 100%);pointer-events:none}
+.hero-inner{position:relative;z-index:1}
 .hero-img{max-width:360px;border-radius:20px;box-shadow:var(--shadow)}
 
 /* SECTIONS */
@@ -105,8 +112,15 @@ body{
 .faq-item:hover{transform:translateY(-6px);box-shadow:0 12px 28px rgba(0,0,0,0.12)}
 
 /* CTA HERO */
-.cta-hero{background:var(--accent-gradient);color:var(--black);text-align:center;padding:48px 0;border-radius:12px}
-.cta-inner{max-width:820px;margin:0 auto}
+.cta-hero{position:relative;background:
+  linear-gradient(180deg,rgba(0,0,0,0.4),rgba(0,0,0,0.7)),
+  url('images/PartherMan2.jpg');
+  background-size:cover;
+  background-position:center;
+  background-repeat:no-repeat;
+  color:var(--white);text-align:center;padding:48px 0;border-radius:12px;overflow:hidden}
+.cta-hero::before{content:"";position:absolute;inset:0;background:linear-gradient(120deg,rgba(0,0,0,0.45),rgba(0,0,0,0.2) 40%,rgba(0,0,0,0.65));pointer-events:none}
+.cta-inner{max-width:820px;margin:0 auto;position:relative;z-index:1}
 
 /* PRODUCTS PAGE */
 .products-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:18px;margin-top:18px}


### PR DESCRIPTION
## Summary
- layer the main hero background over a full-bleed image with centered positioning and cover sizing
- add a dedicated overlay gradient to keep hero text legible
- restyle the CTA hero banner with a photographic background, gradient overlay, and preserved spacing

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e15556c180832798e9280d6d6c8d33