### PR TITLE
Add searchable city selection and sync city list

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,6 +117,12 @@
 
     <div class="calc-grid">
       <div class="calc-controls">
+        <label class="calc-label" for="citySearch">
+          Поиск города:
+          <input type="search" id="citySearch" placeholder="Начните вводить город" autocomplete="off" aria-describedby="cityHelp" list="cityOptions">
+        </label>
+        <p id="cityHelp" class="calc-note calc-note--inline">Можно вводить название — мы подсветим подходящий город.</p>
+        <datalist id="cityOptions"></datalist>
         <label class="calc-label">
           Город:
           <select id="citySelect" aria-label="Город"></select>
@@ -328,85 +334,158 @@
     <h2 class="section-title">Работа курьером доступна в городах</h2>
     <p class="lead">Выбирайте удобный для вас населённый пункт — подключение доступно во многих регионах России.</p>
     <div class="cities-grid" role="list">
-      <span class="city" role="listitem">Москва</span>
-      <span class="city" role="listitem">Санкт-Петербург</span>
-      <span class="city" role="listitem">Екатеринбург</span>
-      <span class="city" role="listitem">Новосибирск</span>
-      <span class="city" role="listitem">Казань</span>
-      <span class="city" role="listitem">Нижний Новгород</span>
-      <span class="city" role="listitem">Самара</span>
-      <span class="city" role="listitem">Уфа</span>
-      <span class="city" role="listitem">Красноярск</span>
-      <span class="city" role="listitem">Челябинск</span>
-      <span class="city" role="listitem">Омск</span>
-      <span class="city" role="listitem">Ростов-на-Дону</span>
-      <span class="city" role="listitem">Воронеж</span>
-      <span class="city" role="listitem">Пермь</span>
-      <span class="city" role="listitem">Волгоград</span>
-      <span class="city" role="listitem">Краснодар</span>
-      <span class="city" role="listitem">Саратов</span>
-      <span class="city" role="listitem">Тюмень</span>
-      <span class="city" role="listitem">Тольятти</span>
-      <span class="city" role="listitem">Ижевск</span>
-      <span class="city" role="listitem">Барнаул</span>
-      <span class="city" role="listitem">Ульяновск</span>
-      <span class="city" role="listitem">Иркутск</span>
-      <span class="city" role="listitem">Хабаровск</span>
-      <span class="city" role="listitem">Ярославль</span>
-      <span class="city" role="listitem">Владивосток</span>
-      <span class="city" role="listitem">Махачкала</span>
-      <span class="city" role="listitem">Томск</span>
-      <span class="city" role="listitem">Оренбург</span>
-      <span class="city" role="listitem">Кемерово</span>
-      <span class="city" role="listitem">Новокузнецк</span>
-      <span class="city" role="listitem">Рязань</span>
-      <span class="city" role="listitem">Астрахань</span>
-      <span class="city" role="listitem">Пенза</span>
-      <span class="city" role="listitem">Липецк</span>
-      <span class="city" role="listitem">Киров</span>
-      <span class="city" role="listitem">Чебоксары</span>
-      <span class="city" role="listitem">Тверь</span>
-      <span class="city" role="listitem">Калуга</span>
-      <span class="city" role="listitem">Белгород</span>
-      <span class="city" role="listitem">Сочи</span>
-      <span class="city" role="listitem">Ставрополь</span>
-      <span class="city" role="listitem">Тула</span>
-      <span class="city" role="listitem">Брянск</span>
-      <span class="city" role="listitem">Курск</span>
-      <span class="city" role="listitem">Архангельск</span>
-      <span class="city" role="listitem">Мурманск</span>
-      <span class="city" role="listitem">Псков</span>
-      <span class="city" role="listitem">Смоленск</span>
-      <span class="city" role="listitem">Вологда</span>
-      <span class="city" role="listitem">Калининград</span>
-      <span class="city" role="listitem">Кострома</span>
-      <span class="city" role="listitem">Иваново</span>
-      <span class="city" role="listitem">Якутск</span>
-      <span class="city" role="listitem">Сургут</span>
-      <span class="city" role="listitem">Набережные Челны</span>
-      <span class="city" role="listitem">Череповец</span>
-      <span class="city" role="listitem">Комсомольск-на-Амуре</span>
-      <span class="city" role="listitem">Березники</span>
-      <span class="city" role="listitem">Подольск</span>
-      <span class="city" role="listitem">Мытищи</span>
-      <span class="city" role="listitem">Химки</span>
-      <span class="city" role="listitem">Люберцы</span>
-      <span class="city" role="listitem">Королёв</span>
-      <span class="city" role="listitem">Домодедово</span>
-      <span class="city" role="listitem">Жуковский</span>
-      <span class="city" role="listitem">Пушкино</span>
-      <span class="city" role="listitem">Электросталь</span>
-      <span class="city" role="listitem">Балашиха</span>
-      <span class="city" role="listitem">Реутов</span>
-      <span class="city" role="listitem">Долгопрудный</span>
-      <span class="city" role="listitem">Коломна</span>
-      <span class="city" role="listitem">Серпухов</span>
-      <span class="city" role="listitem">Железнодорожный</span>
-      <span class="city" role="listitem">Клин</span>
-      <span class="city" role="listitem">Одинцово</span>
-      <span class="city" role="listitem">Дмитров</span>
-      <span class="city" role="listitem">Зеленоград</span>
-      <span class="city" role="listitem">Щёлково</span>
+      <span class="city" role="listitem" data-city-name="Абакан">Абакан</span>
+      <span class="city" role="listitem" data-city-name="Адлер">Адлер</span>
+      <span class="city" role="listitem" data-city-name="Альметьевск">Альметьевск</span>
+      <span class="city" role="listitem" data-city-name="Анапа">Анапа</span>
+      <span class="city" role="listitem" data-city-name="Апрелевка">Апрелевка</span>
+      <span class="city" role="listitem" data-city-name="Армавир">Армавир</span>
+      <span class="city" role="listitem" data-city-name="Архангельск">Архангельск</span>
+      <span class="city" role="listitem" data-city-name="Астрахань">Астрахань</span>
+      <span class="city" role="listitem" data-city-name="Балаково">Балаково</span>
+      <span class="city" role="listitem" data-city-name="Балашиха">Балашиха</span>
+      <span class="city" role="listitem" data-city-name="Барнаул">Барнаул</span>
+      <span class="city" role="listitem" data-city-name="Батайск">Батайск</span>
+      <span class="city" role="listitem" data-city-name="Белгород">Белгород</span>
+      <span class="city" role="listitem" data-city-name="Бердск">Бердск</span>
+      <span class="city" role="listitem" data-city-name="Благовещенск">Благовещенск</span>
+      <span class="city" role="listitem" data-city-name="Бронницы">Бронницы</span>
+      <span class="city" role="listitem" data-city-name="Брянск">Брянск</span>
+      <span class="city" role="listitem" data-city-name="Великий Новгород">Великий Новгород</span>
+      <span class="city" role="listitem" data-city-name="Видное">Видное</span>
+      <span class="city" role="listitem" data-city-name="Владивосток">Владивосток</span>
+      <span class="city" role="listitem" data-city-name="Владикавказ">Владикавказ</span>
+      <span class="city" role="listitem" data-city-name="Владимир">Владимир</span>
+      <span class="city" role="listitem" data-city-name="Волгоград">Волгоград</span>
+      <span class="city" role="listitem" data-city-name="Волжский">Волжский</span>
+      <span class="city" role="listitem" data-city-name="Вологда">Вологда</span>
+      <span class="city" role="listitem" data-city-name="Воронеж">Воронеж</span>
+      <span class="city" role="listitem" data-city-name="Воскресенск">Воскресенск</span>
+      <span class="city" role="listitem" data-city-name="Всеволжск">Всеволжск</span>
+      <span class="city" role="listitem" data-city-name="Выборг">Выборг</span>
+      <span class="city" role="listitem" data-city-name="Гатчина">Гатчина</span>
+      <span class="city" role="listitem" data-city-name="Геленджик">Геленджик</span>
+      <span class="city" role="listitem" data-city-name="Дзержинск">Дзержинск</span>
+      <span class="city" role="listitem" data-city-name="Дзержинский">Дзержинский</span>
+      <span class="city" role="listitem" data-city-name="Дмитров">Дмитров</span>
+      <span class="city" role="listitem" data-city-name="Долгопрудный">Долгопрудный</span>
+      <span class="city" role="listitem" data-city-name="Домодедово">Домодедово</span>
+      <span class="city" role="listitem" data-city-name="Дубна">Дубна</span>
+      <span class="city" role="listitem" data-city-name="Егорьевск">Егорьевск</span>
+      <span class="city" role="listitem" data-city-name="Екатеринбург">Екатеринбург</span>
+      <span class="city" role="listitem" data-city-name="Елабуга">Елабуга</span>
+      <span class="city" role="listitem" data-city-name="Ессентуки">Ессентуки</span>
+      <span class="city" role="listitem" data-city-name="Железнодорожный">Железнодорожный</span>
+      <span class="city" role="listitem" data-city-name="Звенигород">Звенигород</span>
+      <span class="city" role="listitem" data-city-name="Зеленоград">Зеленоград</span>
+      <span class="city" role="listitem" data-city-name="Иваново">Иваново</span>
+      <span class="city" role="listitem" data-city-name="Ивантеевка">Ивантеевка</span>
+      <span class="city" role="listitem" data-city-name="Ижевск">Ижевск</span>
+      <span class="city" role="listitem" data-city-name="Иркутск">Иркутск</span>
+      <span class="city" role="listitem" data-city-name="Йошкар-Ола">Йошкар-Ола</span>
+      <span class="city" role="listitem" data-city-name="Казань">Казань</span>
+      <span class="city" role="listitem" data-city-name="Калининград">Калининград</span>
+      <span class="city" role="listitem" data-city-name="Калуга">Калуга</span>
+      <span class="city" role="listitem" data-city-name="Кемерово">Кемерово</span>
+      <span class="city" role="listitem" data-city-name="Кингисепп">Кингисепп</span>
+      <span class="city" role="listitem" data-city-name="Киров">Киров</span>
+      <span class="city" role="listitem" data-city-name="Кисловодск">Кисловодск</span>
+      <span class="city" role="listitem" data-city-name="Клин">Клин</span>
+      <span class="city" role="listitem" data-city-name="Ковров">Ковров</span>
+      <span class="city" role="listitem" data-city-name="Коломна">Коломна</span>
+      <span class="city" role="listitem" data-city-name="Колпино">Колпино</span>
+      <span class="city" role="listitem" data-city-name="Королёв">Королёв</span>
+      <span class="city" role="listitem" data-city-name="Кострома">Кострома</span>
+      <span class="city" role="listitem" data-city-name="Котельники">Котельники</span>
+      <span class="city" role="listitem" data-city-name="Красногорск">Красногорск</span>
+      <span class="city" role="listitem" data-city-name="Краснодар">Краснодар</span>
+      <span class="city" role="listitem" data-city-name="Красноярск">Красноярск</span>
+      <span class="city" role="listitem" data-city-name="Курган">Курган</span>
+      <span class="city" role="listitem" data-city-name="Курск">Курск</span>
+      <span class="city" role="listitem" data-city-name="Лобня">Лобня</span>
+      <span class="city" role="listitem" data-city-name="Лыткарино">Лыткарино</span>
+      <span class="city" role="listitem" data-city-name="Люберцы">Люберцы</span>
+      <span class="city" role="listitem" data-city-name="Магнитогорск">Магнитогорск</span>
+      <span class="city" role="listitem" data-city-name="Майкоп">Майкоп</span>
+      <span class="city" role="listitem" data-city-name="Махачкала">Махачкала</span>
+      <span class="city" role="listitem" data-city-name="Москва">Москва</span>
+      <span class="city" role="listitem" data-city-name="Мурманск">Мурманск</span>
+      <span class="city" role="listitem" data-city-name="Мытищи">Мытищи</span>
+      <span class="city" role="listitem" data-city-name="Набережные Челны">Набережные Челны</span>
+      <span class="city" role="listitem" data-city-name="Нальчик">Нальчик</span>
+      <span class="city" role="listitem" data-city-name="Наро-Фоминск">Наро-Фоминск</span>
+      <span class="city" role="listitem" data-city-name="Нефтекамск">Нефтекамск</span>
+      <span class="city" role="listitem" data-city-name="Нижневартовск">Нижневартовск</span>
+      <span class="city" role="listitem" data-city-name="Нижнекамск">Нижнекамск</span>
+      <span class="city" role="listitem" data-city-name="Нижний Новгород">Нижний Новгород</span>
+      <span class="city" role="listitem" data-city-name="Нижний Тагил">Нижний Тагил</span>
+      <span class="city" role="listitem" data-city-name="Новокузнецк">Новокузнецк</span>
+      <span class="city" role="listitem" data-city-name="Новомосковск">Новомосковск</span>
+      <span class="city" role="listitem" data-city-name="Новороссийск">Новороссийск</span>
+      <span class="city" role="listitem" data-city-name="Новосибирск">Новосибирск</span>
+      <span class="city" role="listitem" data-city-name="Новочеркасск">Новочеркасск</span>
+      <span class="city" role="listitem" data-city-name="Новый Уренгой">Новый Уренгой</span>
+      <span class="city" role="listitem" data-city-name="Ногинск">Ногинск</span>
+      <span class="city" role="listitem" data-city-name="Обнинск">Обнинск</span>
+      <span class="city" role="listitem" data-city-name="Одинцово">Одинцово</span>
+      <span class="city" role="listitem" data-city-name="Омск">Омск</span>
+      <span class="city" role="listitem" data-city-name="Оренбург">Оренбург</span>
+      <span class="city" role="listitem" data-city-name="Орехово-Зуево">Орехово-Зуево</span>
+      <span class="city" role="listitem" data-city-name="Орёл">Орёл</span>
+      <span class="city" role="listitem" data-city-name="Павловский Посад">Павловский Посад</span>
+      <span class="city" role="listitem" data-city-name="Пенза">Пенза</span>
+      <span class="city" role="listitem" data-city-name="Пермь">Пермь</span>
+      <span class="city" role="listitem" data-city-name="Петрозаводск">Петрозаводск</span>
+      <span class="city" role="listitem" data-city-name="Подольск">Подольск</span>
+      <span class="city" role="listitem" data-city-name="Псков">Псков</span>
+      <span class="city" role="listitem" data-city-name="Пушкин">Пушкин</span>
+      <span class="city" role="listitem" data-city-name="Пушкино">Пушкино</span>
+      <span class="city" role="listitem" data-city-name="Пятигорск">Пятигорск</span>
+      <span class="city" role="listitem" data-city-name="Раменское">Раменское</span>
+      <span class="city" role="listitem" data-city-name="Реутов">Реутов</span>
+      <span class="city" role="listitem" data-city-name="Ростов-на-Дону">Ростов-на-Дону</span>
+      <span class="city" role="listitem" data-city-name="Рязань">Рязань</span>
+      <span class="city" role="listitem" data-city-name="Самара">Самара</span>
+      <span class="city" role="listitem" data-city-name="Санкт-Петербург (СПБ)">Санкт-Петербург (СПБ)</span>
+      <span class="city" role="listitem" data-city-name="Саранск">Саранск</span>
+      <span class="city" role="listitem" data-city-name="Саратов">Саратов</span>
+      <span class="city" role="listitem" data-city-name="Северодвинск">Северодвинск</span>
+      <span class="city" role="listitem" data-city-name="Сергиев Посад">Сергиев Посад</span>
+      <span class="city" role="listitem" data-city-name="Серпухов">Серпухов</span>
+      <span class="city" role="listitem" data-city-name="Смоленск">Смоленск</span>
+      <span class="city" role="listitem" data-city-name="Солнечногорск">Солнечногорск</span>
+      <span class="city" role="listitem" data-city-name="Сочи">Сочи</span>
+      <span class="city" role="listitem" data-city-name="Ставрополь">Ставрополь</span>
+      <span class="city" role="listitem" data-city-name="Старый Оскол">Старый Оскол</span>
+      <span class="city" role="listitem" data-city-name="Стерлитамак">Стерлитамак</span>
+      <span class="city" role="listitem" data-city-name="Ступино">Ступино</span>
+      <span class="city" role="listitem" data-city-name="Сургут">Сургут</span>
+      <span class="city" role="listitem" data-city-name="Сыктывкар">Сыктывкар</span>
+      <span class="city" role="listitem" data-city-name="Таганрог">Таганрог</span>
+      <span class="city" role="listitem" data-city-name="Тамбов">Тамбов</span>
+      <span class="city" role="listitem" data-city-name="Тверь">Тверь</span>
+      <span class="city" role="listitem" data-city-name="Тобольск">Тобольск</span>
+      <span class="city" role="listitem" data-city-name="Тольятти">Тольятти</span>
+      <span class="city" role="listitem" data-city-name="Томск">Томск</span>
+      <span class="city" role="listitem" data-city-name="Троицк">Троицк</span>
+      <span class="city" role="listitem" data-city-name="Тула">Тула</span>
+      <span class="city" role="listitem" data-city-name="Тюмень">Тюмень</span>
+      <span class="city" role="listitem" data-city-name="Ульяновск">Ульяновск</span>
+      <span class="city" role="listitem" data-city-name="Уссурийск">Уссурийск</span>
+      <span class="city" role="listitem" data-city-name="Уфа">Уфа</span>
+      <span class="city" role="listitem" data-city-name="Фрязино">Фрязино</span>
+      <span class="city" role="listitem" data-city-name="Хабаровск">Хабаровск</span>
+      <span class="city" role="listitem" data-city-name="Ханты-Мансийск">Ханты-Мансийск</span>
+      <span class="city" role="listitem" data-city-name="Химки">Химки</span>
+      <span class="city" role="listitem" data-city-name="Чебоксары">Чебоксары</span>
+      <span class="city" role="listitem" data-city-name="Челябинск">Челябинск</span>
+      <span class="city" role="listitem" data-city-name="Череповец">Череповец</span>
+      <span class="city" role="listitem" data-city-name="Чехов">Чехов</span>
+      <span class="city" role="listitem" data-city-name="Шахты">Шахты</span>
+      <span class="city" role="listitem" data-city-name="Щербинка">Щербинка</span>
+      <span class="city" role="listitem" data-city-name="Щёлково">Щёлково</span>
+      <span class="city" role="listitem" data-city-name="Электросталь">Электросталь</span>
+      <span class="city" role="listitem" data-city-name="Ярославль">Ярославль</span>
     </div>
   </div>
 </section>

--- a/script.js
+++ b/script.js
@@ -7,24 +7,199 @@ const MODE_OPTIONS = [
   { key: 'auto', label: 'Авто', hourlyRate: 550 }
 ];
 
-const CITY_DATA = [
-  { name: 'Москва', multiplier: 1.2 },
-  { name: 'Санкт‑Петербург', multiplier: 1.15 },
-  { name: 'Екатеринбург', multiplier: 1.1 },
-  { name: 'Новосибирск', multiplier: 1.05 },
-  { name: 'Казань', multiplier: 1.05 },
-  { name: 'Краснодар', multiplier: 1.05 },
-  { name: 'Нижний Новгород', multiplier: 1.0 },
-  { name: 'Ростов-на-Дону', multiplier: 1.0 },
-  { name: 'Самара', multiplier: 1.0 },
-  { name: 'Уфа', multiplier: 0.95 },
-  { name: 'Пермь', multiplier: 0.95 },
-  { name: 'Воронеж', multiplier: 0.95 },
-  { name: 'Челябинск', multiplier: 0.95 },
-  { name: 'Красноярск', multiplier: 0.9 },
-  { name: 'Омск', multiplier: 0.9 },
-  { name: 'Саратов', multiplier: 0.9 }
+const DEFAULT_CITY_MULTIPLIER = 0.95;
+const CITY_MULTIPLIERS = {
+  'Москва': 1.2,
+  'Санкт-Петербург (СПБ)': 1.15,
+  'Екатеринбург': 1.1,
+  'Новосибирск': 1.05,
+  'Казань': 1.05,
+  'Краснодар': 1.05,
+  'Нижний Новгород': 1.0,
+  'Ростов-на-Дону': 1.0,
+  'Самара': 1.0,
+  'Сочи': 1.0,
+  'Нижневартовск': 1.0,
+  'Сургут': 1.02,
+  'Ханты-Мансийск': 1.02,
+  'Новый Уренгой': 1.02,
+  'Калининград': 0.98,
+  'Красноярск': 0.98,
+  'Тюмень': 0.98,
+  'Мурманск': 0.97,
+  'Тольятти': 0.96,
+  'Уфа': 0.95,
+  'Пермь': 0.95,
+  'Воронеж': 0.95,
+  'Челябинск': 0.95,
+  'Волгоград': 0.95,
+  'Ярославль': 0.95,
+  'Омск': 0.93,
+  'Саратов': 0.93,
+  'Магнитогорск': 0.94
+};
+
+const CITY_NAMES = [
+  'Абакан',
+  'Адлер',
+  'Альметьевск',
+  'Анапа',
+  'Апрелевка',
+  'Армавир',
+  'Архангельск',
+  'Астрахань',
+  'Балаково',
+  'Балашиха',
+  'Барнаул',
+  'Батайск',
+  'Белгород',
+  'Бердск',
+  'Благовещенск',
+  'Бронницы',
+  'Брянск',
+  'Великий Новгород',
+  'Видное',
+  'Владивосток',
+  'Владикавказ',
+  'Владимир',
+  'Волгоград',
+  'Волжский',
+  'Вологда',
+  'Воронеж',
+  'Воскресенск',
+  'Всеволжск',
+  'Выборг',
+  'Гатчина',
+  'Геленджик',
+  'Дзержинск',
+  'Дзержинский',
+  'Дмитров',
+  'Долгопрудный',
+  'Домодедово',
+  'Дубна',
+  'Егорьевск',
+  'Екатеринбург',
+  'Елабуга',
+  'Ессентуки',
+  'Железнодорожный',
+  'Звенигород',
+  'Зеленоград',
+  'Иваново',
+  'Ивантеевка',
+  'Ижевск',
+  'Иркутск',
+  'Йошкар-Ола',
+  'Казань',
+  'Калининград',
+  'Калуга',
+  'Кемерово',
+  'Кингисепп',
+  'Киров',
+  'Кисловодск',
+  'Клин',
+  'Ковров',
+  'Коломна',
+  'Колпино',
+  'Королёв',
+  'Кострома',
+  'Котельники',
+  'Красногорск',
+  'Краснодар',
+  'Красноярск',
+  'Курган',
+  'Курск',
+  'Лобня',
+  'Лыткарино',
+  'Люберцы',
+  'Магнитогорск',
+  'Майкоп',
+  'Махачкала',
+  'Москва',
+  'Мурманск',
+  'Мытищи',
+  'Набережные Челны',
+  'Нальчик',
+  'Наро-Фоминск',
+  'Нефтекамск',
+  'Нижневартовск',
+  'Нижнекамск',
+  'Нижний Новгород',
+  'Нижний Тагил',
+  'Новокузнецк',
+  'Новомосковск',
+  'Новороссийск',
+  'Новосибирск',
+  'Новочеркасск',
+  'Новый Уренгой',
+  'Ногинск',
+  'Обнинск',
+  'Одинцово',
+  'Омск',
+  'Оренбург',
+  'Орехово-Зуево',
+  'Орёл',
+  'Павловский Посад',
+  'Пенза',
+  'Пермь',
+  'Петрозаводск',
+  'Подольск',
+  'Псков',
+  'Пушкин',
+  'Пушкино',
+  'Пятигорск',
+  'Раменское',
+  'Реутов',
+  'Ростов-на-Дону',
+  'Рязань',
+  'Самара',
+  'Санкт-Петербург (СПБ)',
+  'Саранск',
+  'Саратов',
+  'Северодвинск',
+  'Сергиев Посад',
+  'Серпухов',
+  'Смоленск',
+  'Солнечногорск',
+  'Сочи',
+  'Ставрополь',
+  'Старый Оскол',
+  'Стерлитамак',
+  'Ступино',
+  'Сургут',
+  'Сыктывкар',
+  'Таганрог',
+  'Тамбов',
+  'Тверь',
+  'Тобольск',
+  'Тольятти',
+  'Томск',
+  'Троицк',
+  'Тула',
+  'Тюмень',
+  'Ульяновск',
+  'Уссурийск',
+  'Уфа',
+  'Фрязино',
+  'Хабаровск',
+  'Ханты-Мансийск',
+  'Химки',
+  'Чебоксары',
+  'Челябинск',
+  'Череповец',
+  'Чехов',
+  'Шахты',
+  'Щербинка',
+  'Щёлково',
+  'Электросталь',
+  'Ярославль'
 ];
+
+const CITY_DATA = CITY_NAMES.map(name => ({
+  name,
+  multiplier: CITY_MULTIPLIERS[name] ?? DEFAULT_CITY_MULTIPLIER
+}));
+
+const DEFAULT_CITY_NAME = 'Москва';
 
 // script.js — минимальная логика: модал формы, анимация появления и отправка формы (локально)
 document.addEventListener('DOMContentLoaded', function () {
@@ -91,22 +266,6 @@ document.addEventListener('DOMContentLoaded', function () {
   window.addEventListener('scroll', showOnScroll);
 });
 
-// ===== Build city tags dynamically from CITY_DATA
-(function buildCityTags(){
-  const tags = document.getElementById('citiesTags');
-  if(!tags) return;
-  tags.innerHTML = '';
-  CITY_DATA.forEach((c, idx) => {
-    const b = document.createElement('button');
-    b.className = 'city-tag';
-    b.setAttribute('role','listitem');
-    b.setAttribute('data-city', c.name);
-    b.textContent = c.name;
-    if(idx < 18) b.classList.add('highlight'); // визуальный приоритет крупнейшим
-    tags.appendChild(b);
-  });
-})();
-
 // ===== calc tips
 const MODE_TIPS = {
   walk: 'Пеший курьер — удобнее в центре и рядом с метро. Ставьте короткие слоты в час-пик.',
@@ -131,6 +290,25 @@ document.addEventListener('input', (e)=>{
 });
 document.addEventListener('DOMContentLoaded', updateCalcHint);
 
+function normalizeCityString(value) {
+  return (value || '')
+    .toLowerCase()
+    .replace(/ё/g, 'е')
+    .replace(/[^a-zа-я0-9]/gi, '');
+}
+
+function highlightCityInList(cityName) {
+  const items = document.querySelectorAll('[data-city-name]');
+  if (!items.length) return;
+  items.forEach(item => {
+    if (cityName && item.dataset.cityName === cityName) {
+      item.classList.add('is-active');
+    } else {
+      item.classList.remove('is-active');
+    }
+  });
+}
+
 /**
  * Populate select options for city and mode, and set up event listeners
  */
@@ -144,8 +322,16 @@ function initCalculator() {
   const dayIncome = document.getElementById('dayIncome');
   const weekIncome = document.getElementById('weekIncome');
   const monthIncome = document.getElementById('monthIncome');
+  const citySearch = document.getElementById('citySearch');
+  const cityDatalist = document.getElementById('cityOptions');
+  const cityGrid = document.querySelector('.cities-grid');
 
   if (!citySelect || !modeSelect) return;
+
+  citySelect.innerHTML = '';
+  if (cityDatalist) {
+    cityDatalist.innerHTML = '';
+  }
 
   // Populate city options
   CITY_DATA.forEach(city => {
@@ -153,8 +339,17 @@ function initCalculator() {
     opt.value = city.name;
     opt.textContent = city.name;
     citySelect.appendChild(opt);
+    if (cityDatalist) {
+      const option = document.createElement('option');
+      option.value = city.name;
+      cityDatalist.appendChild(option);
+    }
   });
-  citySelect.selectedIndex = 0;
+
+  const fallbackCity = CITY_DATA.find(c => c.name === DEFAULT_CITY_NAME) || CITY_DATA[0];
+  if (fallbackCity) {
+    citySelect.value = fallbackCity.name;
+  }
 
   // Populate mode options
   MODE_OPTIONS.forEach(optData => {
@@ -208,13 +403,64 @@ function initCalculator() {
     }
     hoursValue.textContent = hours;
     daysValue.textContent = days;
+    if (city) {
+      highlightCityInList(city.name);
+    } else {
+      highlightCityInList(null);
+    }
+    if (citySearch && city && document.activeElement !== citySearch) {
+      citySearch.value = city.name;
+    }
   }
 
   // Listen to changes
-  citySelect.addEventListener('change', () => { updateIncome(); updateCalcHint(); });
+  citySelect.addEventListener('change', () => {
+    updateIncome();
+    updateCalcHint();
+    if (citySearch && document.activeElement !== citySearch) {
+      citySearch.value = citySelect.value;
+    }
+  });
   modeSelect.addEventListener('change', () => { updateActiveModeIcon(); updateIncome(); updateCalcHint(); });
   hoursRange.addEventListener('input', updateIncome);
   daysRange.addEventListener('input', updateIncome);
+
+  if (citySearch) {
+    citySearch.addEventListener('input', () => {
+      const normalizedQuery = normalizeCityString(citySearch.value);
+      if (!normalizedQuery) {
+        if (fallbackCity) {
+          citySelect.value = fallbackCity.name;
+          updateIncome();
+          updateCalcHint();
+        }
+        return;
+      }
+      const match = CITY_DATA.find(city => normalizeCityString(city.name).includes(normalizedQuery));
+      if (match) {
+        citySelect.value = match.name;
+        updateIncome();
+        updateCalcHint();
+      } else {
+        highlightCityInList(null);
+      }
+    });
+  }
+
+  if (cityGrid) {
+    cityGrid.addEventListener('click', (event) => {
+      const target = event.target.closest('[data-city-name]');
+      if (!target) return;
+      const cityName = target.dataset.cityName;
+      if (!cityName) return;
+      citySelect.value = cityName;
+      updateIncome();
+      updateCalcHint();
+      if (citySearch) {
+        citySearch.value = cityName;
+      }
+    });
+  }
 
   // Initialize
   updateActiveModeIcon();

--- a/style.css
+++ b/style.css
@@ -64,6 +64,7 @@ body{
 .cities-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:12px;margin:28px auto 0;max-width:var(--max-width)}
 .cities-grid .city{background:#fff;border-radius:14px;box-shadow:var(--shadow);padding:12px 16px;font-weight:600;color:#1f1f1f;text-align:center;display:flex;align-items:center;justify-content:center;transition:transform .2s ease,box-shadow .2s ease;font-size:15px;letter-spacing:.1px}
 .cities-grid .city:hover{transform:translateY(-4px);box-shadow:0 14px 32px rgba(0,0,0,0.12)}
+.cities-grid .city.is-active{border:2px solid var(--orange);box-shadow:0 18px 40px rgba(255,102,0,0.16);transform:translateY(-4px);color:var(--orange)}
 
 /* FEATURES GRID */
 .grid-4{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:18px}
@@ -263,6 +264,22 @@ body{
   background:#fff;
   font-size:14px;
   color:#000;
+}
+.calc-label input[type="search"]{
+  padding:8px 10px;
+  border:1px solid #d4d4d4;
+  border-radius:8px;
+  background:#fff;
+  font-size:14px;
+  color:#000;
+}
+.calc-note{
+  margin:0;
+  font-size:13px;
+  color:#555;
+}
+.calc-note--inline{
+  margin-top:-6px;
 }
 input[type="range"]{
   accent-color:var(--orange);


### PR DESCRIPTION
## Summary
- add a search field with datalist suggestions to the calculator and wire it to update the selected city
- expand the city data to cover all partner locations, keep the list alphabetical, and highlight the active city in the footer grid
- style the new search control and active city chips so the selection stands out visually

## Testing
- No automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e153ce62188327985a7cbc5294756e