### PR TITLE
Smoothly scroll to calculator when selecting a city

### DIFF
--- a/script.js
+++ b/script.js
@@ -456,6 +456,10 @@ function initCalculator() {
       citySelect.value = cityName;
       updateIncome();
       updateCalcHint();
+      const calcSection = document.getElementById('calc');
+      if (calcSection) {
+        calcSection.scrollIntoView({ behavior: 'smooth' });
+      }
       if (citySearch) {
         citySearch.value = cityName;
       }


### PR DESCRIPTION
## Summary
- trigger a smooth scroll to the calculator when a city is chosen from the grid

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e15f4055a4832784456b06a7c39b3d