### PR TITLE
Handle missing modal element gracefully

### DIFF
--- a/script.js
+++ b/script.js
@@ -211,19 +211,23 @@ document.addEventListener('DOMContentLoaded', function () {
 
   function openModal(e){
     e && e.preventDefault();
+    if (!modal) return;
     modal.setAttribute('aria-hidden','false');
     document.body.style.overflow = 'hidden';
   }
   function closeModal(){
+    if (!modal) return;
     modal.setAttribute('aria-hidden','true');
     document.body.style.overflow = '';
   }
   openBtns.forEach(b=> b && b.addEventListener('click', openModal));
   closeBtn && closeBtn.addEventListener('click', closeModal);
   cancelBtn && cancelBtn.addEventListener('click', closeModal);
-  modal.addEventListener('click', function(e){
-    if(e.target === modal) closeModal();
-  });
+  if (modal) {
+    modal.addEventListener('click', function(e){
+      if(e.target === modal) closeModal();
+    });
+  }
 
   // Simple form handling (local demo)
   const form = document.getElementById('applyForm');


### PR DESCRIPTION
## Summary
- guard modal open/close handlers so they no longer touch a missing modal element
- keep other DOM initialization running while safely skipping modal-specific listeners when absent

## Testing
- browser_container.run_playwright_script (console check)

------
https://chatgpt.com/codex/tasks/task_e_68e16e2b82908327be273b9393cc8c61