### PR TITLE
Add gradient dividers and dark theme styling to FAQ and city cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,9 +109,11 @@
       </div>
     </div>
   </div>
+</section>
+
+<div class="section-divider section-divider--accent" aria-hidden="true"></div>
 
 <!-- ===== CALCULATOR (restored) ===== -->
-  </div>
 <div class="grouped-sections section-bg-2">
   <section class="section calc" id="calc" aria-labelledby="calc-title">
     <div class="container">
@@ -220,6 +222,8 @@
 
 
 
+
+<div class="section-divider section-divider--accent" aria-hidden="true"></div>
 
 <!-- ===== TESTIMONIALS ===== -->
 <section class="section testimonials section-bg-3" id="reviews">

--- a/style.css
+++ b/style.css
@@ -78,9 +78,9 @@ body{
 /* Cities */
 .section.cities{background-color:var(--muted)}
 .cities-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:12px;margin:28px auto 0;max-width:var(--max-width)}
-.cities-grid .city{background:#fff;border-radius:14px;box-shadow:var(--shadow);padding:12px 16px;font-weight:600;color:#1f1f1f;text-align:center;display:flex;align-items:center;justify-content:center;transition:transform .2s ease,box-shadow .2s ease;font-size:15px;letter-spacing:.1px}
-.cities-grid .city:hover{transform:translateY(-4px);box-shadow:0 14px 32px rgba(0,0,0,0.12)}
-.cities-grid .city.is-active{border:2px solid var(--orange);box-shadow:0 18px 40px rgba(255,102,0,0.16);transform:translateY(-4px);color:var(--orange)}
+.cities-grid .city{background:rgba(11,11,11,0.85);border-radius:14px;box-shadow:0 18px 44px rgba(0,0,0,0.32);padding:12px 16px;font-weight:600;color:rgba(255,255,255,0.92);text-align:center;display:flex;align-items:center;justify-content:center;transition:transform .2s ease,box-shadow .2s ease,border-color .2s ease;color .2s ease;font-size:15px;letter-spacing:.1px;border:1px solid rgba(255,255,255,0.08);backdrop-filter:blur(6px)}
+.cities-grid .city:hover{transform:translateY(-4px);box-shadow:0 22px 48px rgba(0,0,0,0.45);border-color:rgba(255,255,255,0.18)}
+.cities-grid .city.is-active{border:2px solid var(--orange);box-shadow:0 24px 54px rgba(255,102,0,0.22);transform:translateY(-4px);color:var(--orange);background:rgba(11,11,11,0.9)}
 
 /* FEATURES GRID */
 .grid-4{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:18px}
@@ -116,10 +116,10 @@ body{
 
 /* FAQ */
 .faq-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:16px;margin-top:20px}
-.faq-item{background:#fff;border-radius:12px;box-shadow:var(--shadow);padding:18px;transition:all .25s ease}
-.faq-item h4{margin:0 0 8px;font-size:17px;font-weight:700}
-.faq-item p{margin:0;color:#444}
-.faq-item:hover{transform:translateY(-6px);box-shadow:0 12px 28px rgba(0,0,0,0.12)}
+.faq-item{background:rgba(11,11,11,0.85);border-radius:12px;box-shadow:0 18px 44px rgba(0,0,0,0.34);padding:18px;transition:transform .25s ease,box-shadow .25s ease,border-color .25s ease;color:rgba(255,255,255,0.88);border:1px solid rgba(255,255,255,0.08);backdrop-filter:blur(6px)}
+.faq-item h4{margin:0 0 8px;font-size:17px;font-weight:700;color:var(--white)}
+.faq-item p{margin:0;color:rgba(255,255,255,0.78)}
+.faq-item:hover{transform:translateY(-6px);box-shadow:0 26px 56px rgba(0,0,0,0.46);border-color:rgba(255,255,255,0.18)}
 
 /* CTA HERO */
 .cta-hero{position:relative;background:var(--accent-gradient);color:#2b1b00;text-align:center;padding:48px 0;border-radius:12px;overflow:hidden}
@@ -135,6 +135,30 @@ body{
 
 .grouped-sections{
   padding:0;
+}
+
+.section-divider{
+  height:26px;
+  width:100%;
+}
+.section-divider--accent{
+  position:relative;
+  overflow:hidden;
+}
+.section-divider--accent::before{
+  content:"";
+  position:absolute;
+  inset:0;
+  background:var(--accent-gradient);
+  opacity:0.75;
+  filter:blur(18px);
+}
+.section-divider--accent::after{
+  content:"";
+  position:absolute;
+  inset:6px 12%;
+  border-radius:999px;
+  background:var(--accent-gradient);
 }
 
 /* PRODUCTS PAGE */
@@ -174,8 +198,10 @@ body{
 
 
 /* TRUSTED FAQ OPEN */
-.faq-head{margin:0;padding:18px 18px 0;font-weight:900}
-.faq-a.open{padding:10px 18px 18px;color:#444;max-height:none!important}
+.faq-head{margin:0;padding:18px 18px 0;font-weight:900;color:var(--white)}
+.faq-a{padding:0 18px 18px;color:rgba(255,255,255,0.75);line-height:1.6;transition:color .2s ease}
+.faq-a.open{padding:10px 18px 18px;color:rgba(255,255,255,0.8);max-height:none!important}
+.faq-item:hover .faq-a{color:rgba(255,255,255,0.88)}
 .partner-badge{display:flex;align-items:center;gap:10px;justify-content:center;margin-bottom:8px}
 .partner-badge img{height:42px;width:auto}
 .partner-badge span{font-weight:900;letter-spacing:.2px}


### PR DESCRIPTION
## Summary
- add reusable gradient section divider between major sections to smooth background transitions
- update FAQ and city cards to use dark hero-inspired styling with improved contrast

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e238d1ad8083278a388d8c8bd639f1