### PR TITLE
Remove intro section overlay dimming

### DIFF
--- a/style.css
+++ b/style.css
@@ -33,7 +33,7 @@ body{
   content:"";
   position:absolute;
   inset:0;
-  background:linear-gradient(180deg,rgba(0,0,0,0.62) 0%,rgba(0,0,0,0.4) 32%,rgba(255,255,255,0.88) 100%);
+  background:transparent;
   z-index:0;
 }
 .top-bg > *{position:relative;z-index:1}


### PR DESCRIPTION
## Summary
- remove the gradient overlay from the intro background so the section is no longer dimmed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e24ea2cfbc8327a434d45d553047a2