### PR TITLE
Add equipment benefit to features section

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,15 +97,15 @@
         <p>Работай рядом с домом — меньше потерь времени на дорогу.</p>
       </div>
       <div class="feature-card">
-        <img class="icon" src="images/icon-training.png" alt="">
+        <img class="icon" src="images/icon-support.png" alt="Поддержка и обучение">
         <h3>Поддержка и обучение</h3>
-        <p>Поможем с регистрацией и дадим полезные советы для быстрого старта.</p>
+        <p>Поможем с регистрацией, расскажем про выгодные слоты и всегда рядом на старте.</p>
       </div>
-    
+
       <div class="feature-card pill">
-        <img loading="lazy" decoding="async" class="icon" src="images/icon-support.png" alt="Поддержка">
-        <h3>Поддержка</h3>
-        <p>Связь на старте и подсказки по выгодным слотам и экипировки.</p>
+        <img loading="lazy" decoding="async" class="icon" src="images/icon-training.png" alt="Экипировка">
+        <h3>Экипировка</h3>
+        <p>Выдаем брендированную форму и защитное снаряжение, чтобы комфортно доставлять заказы.</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- swap the support card icon to highlight onboarding help
- replace the duplicate support pill card with an equipment benefit and refreshed copy

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2a0977e408327b0692e75a7b6aa81