### PR TITLE
Add descriptive alt text for feature icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,22 +82,22 @@
     <h2 class="section-title">Преимущества работы</h2>
     <div class="features-wrap grid-4">
       <div class="feature-card">
-        <img class="icon" src="images/icon-money.png" alt="">
+        <img class="icon" src="images/icon-money.png" alt="Иконка ежедневных выплат">
         <h3>Ежедневные выплаты</h3>
         <p>Выплаты — без задержек и ежедневно.</p>
       </div>
       <div class="feature-card">
-        <img class="icon" src="images/icon-schedule.png" alt="">
+        <img class="icon" src="images/icon-schedule.png" alt="Иконка гибкого графика">
         <h3>Гибкий график</h3>
         <p>Выбирай смены по своему расписанию — утром, вечером или выходные.</p>
       </div>
       <div class="feature-card">
-        <img class="icon" src="images/icon-location.png" alt="">
+        <img class="icon" src="images/icon-location.png" alt="Иконка удобных районов">
         <h3>Удобные районы</h3>
         <p>Работай рядом с домом — меньше потерь времени на дорогу.</p>
       </div>
       <div class="feature-card">
-        <img class="icon" src="images/icon-training.png" alt="">
+        <img class="icon" src="images/icon-training.png" alt="Иконка поддержки и обучения">
         <h3>Поддержка и обучение</h3>
         <p>Поможем с регистрацией и дадим полезные советы для быстрого старта.</p>
       </div>


### PR DESCRIPTION
## Summary
- provide meaningful alt text for key feature icons on the landing page to improve accessibility

## Testing
- npx pa11y http://127.0.0.1:8080/index.html *(fails: Missing shared library libatk-1.0.so.0 while launching Chromium)*

------
https://chatgpt.com/codex/tasks/task_e_68e2a0c9b2088327ae77b2198f0be40e