### PR TITLE
Add accessible FAQ accordion

### DIFF
--- a/index.html
+++ b/index.html
@@ -311,24 +311,59 @@
       <h2 class="section-title">Частые вопросы</h2>
       <div class="faq-grid" role="list">
         <div class="faq-item" role="listitem">
-          <h3 class="faq-head">Нужен ли опыт?</h3>
-          <div class="faq-a open">Нет. Мы подскажем, как начать: анкета, встреча, выход на смену.</div>
+          <h3 class="faq-head">
+            <button class="faq-trigger" type="button" aria-expanded="false" aria-controls="faq-panel-1" id="faq-trigger-1">
+              <span>Нужен ли опыт?</span>
+              <span class="faq-icon" aria-hidden="true"></span>
+            </button>
+          </h3>
+          <div class="faq-a" id="faq-panel-1" role="region" aria-labelledby="faq-trigger-1" aria-hidden="true">
+            Нет. Мы подскажем, как начать: анкета, встреча, выход на смену.
+          </div>
         </div>
         <div class="faq-item" role="listitem">
-          <h3 class="faq-head">Какие документы нужны?</h3>
-          <div class="faq-a open">Паспорт РФ для иностранных граждан пакет документов расширен.</div>
+          <h3 class="faq-head">
+            <button class="faq-trigger" type="button" aria-expanded="false" aria-controls="faq-panel-2" id="faq-trigger-2">
+              <span>Какие документы нужны?</span>
+              <span class="faq-icon" aria-hidden="true"></span>
+            </button>
+          </h3>
+          <div class="faq-a" id="faq-panel-2" role="region" aria-labelledby="faq-trigger-2" aria-hidden="true">
+            Паспорт РФ для иностранных граждан пакет документов расширен.
+          </div>
         </div>
         <div class="faq-item" role="listitem">
-          <h3 class="faq-head">Можно ли без велосипеда?</h3>
-          <div class="faq-a open">Да, можно пешком. Для вело/авто доход зависит от скорости и радиуса. Мы также предоставляем скидки на покупку и аренду транспорта</div>
+          <h3 class="faq-head">
+            <button class="faq-trigger" type="button" aria-expanded="false" aria-controls="faq-panel-3" id="faq-trigger-3">
+              <span>Можно ли без велосипеда?</span>
+              <span class="faq-icon" aria-hidden="true"></span>
+            </button>
+          </h3>
+          <div class="faq-a" id="faq-panel-3" role="region" aria-labelledby="faq-trigger-3" aria-hidden="true">
+            Да, можно пешком. Для вело/авто доход зависит от скорости и радиуса. Мы также предоставляем скидки на покупку и аренду транспорта
+          </div>
         </div>
         <div class="faq-item" role="listitem">
-          <h3 class="faq-head">Как быстро начну зарабатывать?</h3>
-          <div class="faq-a open">Обычно в течение 1–2 дней после регистрации и получения снаряжения.</div>
+          <h3 class="faq-head">
+            <button class="faq-trigger" type="button" aria-expanded="false" aria-controls="faq-panel-4" id="faq-trigger-4">
+              <span>Как быстро начну зарабатывать?</span>
+              <span class="faq-icon" aria-hidden="true"></span>
+            </button>
+          </h3>
+          <div class="faq-a" id="faq-panel-4" role="region" aria-labelledby="faq-trigger-4" aria-hidden="true">
+            Обычно в течение 1–2 дней после регистрации и получения снаряжения.
+          </div>
         </div>
         <div class="faq-item" role="listitem">
-          <h3 class="faq-head">Работа есть по всей России?</h3>
-          <div class="faq-a open">Да, большинство крупных городов и агломераций. Если не видите свой город — оставьте заявку, и с вами свяжется оператор.</div>
+          <h3 class="faq-head">
+            <button class="faq-trigger" type="button" aria-expanded="false" aria-controls="faq-panel-5" id="faq-trigger-5">
+              <span>Работа есть по всей России?</span>
+              <span class="faq-icon" aria-hidden="true"></span>
+            </button>
+          </h3>
+          <div class="faq-a" id="faq-panel-5" role="region" aria-labelledby="faq-trigger-5" aria-hidden="true">
+            Да, большинство крупных городов и агломераций. Если не видите свой город — оставьте заявку, и с вами свяжется оператор.
+          </div>
         </div>
       </div>
     </div>

--- a/script.js
+++ b/script.js
@@ -209,6 +209,58 @@ document.addEventListener('DOMContentLoaded', function () {
   const closeBtn = document.getElementById('modalClose');
   const cancelBtn = document.getElementById('modalCancel');
 
+  // FAQ accordion
+  const faqItems = Array.from(document.querySelectorAll('.faq-item'));
+
+  const closeFaqItem = (item) => {
+    const trigger = item.querySelector('.faq-trigger');
+    const answer = item.querySelector('.faq-a');
+    item.classList.remove('open');
+    if (trigger) {
+      trigger.setAttribute('aria-expanded', 'false');
+    }
+    if (answer) {
+      answer.setAttribute('aria-hidden', 'true');
+    }
+  };
+
+  const openFaqItem = (item) => {
+    const trigger = item.querySelector('.faq-trigger');
+    const answer = item.querySelector('.faq-a');
+    item.classList.add('open');
+    if (trigger) {
+      trigger.setAttribute('aria-expanded', 'true');
+    }
+    if (answer) {
+      answer.setAttribute('aria-hidden', 'false');
+    }
+  };
+
+  if (faqItems.length) {
+    faqItems.forEach((item) => {
+      const trigger = item.querySelector('.faq-trigger');
+      const answer = item.querySelector('.faq-a');
+      if (!trigger || !answer) return;
+
+      // ensure collapsed on load
+      closeFaqItem(item);
+
+      trigger.addEventListener('click', () => {
+        const isOpen = item.classList.contains('open');
+        faqItems.forEach((other) => {
+          if (other !== item) {
+            closeFaqItem(other);
+          }
+        });
+        if (isOpen) {
+          closeFaqItem(item);
+        } else {
+          openFaqItem(item);
+        }
+      });
+    });
+  }
+
   function openModal(e){
     e && e.preventDefault();
     if (!modal) return;

--- a/style.css
+++ b/style.css
@@ -116,10 +116,19 @@ body{
 
 /* FAQ */
 .faq-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:16px;margin-top:20px}
-.faq-item{background:rgba(11,11,11,0.85);border-radius:12px;box-shadow:0 18px 44px rgba(0,0,0,0.34);padding:18px;transition:transform .25s ease,box-shadow .25s ease,border-color .25s ease;color:rgba(255,255,255,0.88);border:1px solid rgba(255,255,255,0.08);backdrop-filter:blur(6px)}
-.faq-item h4{margin:0 0 8px;font-size:17px;font-weight:700;color:var(--white)}
-.faq-item p{margin:0;color:rgba(255,255,255,0.78)}
+.faq-item{background:rgba(11,11,11,0.85);border-radius:12px;box-shadow:0 18px 44px rgba(0,0,0,0.34);transition:transform .25s ease,box-shadow .25s ease,border-color .25s ease,color .25s ease;border:1px solid rgba(255,255,255,0.08);backdrop-filter:blur(6px);color:rgba(255,255,255,0.88);overflow:hidden}
 .faq-item:hover{transform:translateY(-6px);box-shadow:0 26px 56px rgba(0,0,0,0.46);border-color:rgba(255,255,255,0.18)}
+.faq-head{margin:0}
+.faq-trigger{display:flex;align-items:center;gap:16px;justify-content:space-between;width:100%;padding:18px;font:inherit;font-size:18px;font-weight:800;color:var(--white);background:transparent;border:0;cursor:pointer;text-align:left;transition:color .25s ease,background .25s ease}
+.faq-trigger:focus-visible{outline:2px solid var(--accent);outline-offset:3px}
+.faq-item:hover .faq-trigger{color:#fff}
+.faq-icon{position:relative;width:18px;height:18px;flex-shrink:0;color:currentColor}
+.faq-icon::before,.faq-icon::after{content:"";position:absolute;top:50%;left:50%;width:14px;height:2px;background:currentColor;border-radius:2px;transform:translate(-50%,-50%);transition:transform .25s ease,opacity .25s ease}
+.faq-icon::after{transform:translate(-50%,-50%) rotate(90deg)}
+.faq-item.open .faq-icon::after{transform:translate(-50%,-50%) rotate(90deg) scaleY(0);opacity:0}
+.faq-a{padding:0 18px;max-height:0;overflow:hidden;color:rgba(255,255,255,0.75);line-height:1.6;opacity:0;transition:max-height .35s ease,opacity .3s ease,padding .35s ease}
+.faq-item.open .faq-a{padding:10px 18px 18px;max-height:480px;opacity:1;color:rgba(255,255,255,0.82)}
+.faq-item:hover .faq-a{color:rgba(255,255,255,0.88)}
 
 /* CTA HERO */
 .cta-hero{position:relative;background:var(--accent-gradient);color:#2b1b00;text-align:center;padding:48px 0;border-radius:12px;overflow:hidden}
@@ -207,11 +216,6 @@ body{
 }
 
 
-/* TRUSTED FAQ OPEN */
-.faq-head{margin:0;padding:18px 18px 0;font-weight:900;color:var(--white)}
-.faq-a{padding:0 18px 18px;color:rgba(255,255,255,0.75);line-height:1.6;transition:color .2s ease}
-.faq-a.open{padding:10px 18px 18px;color:rgba(255,255,255,0.8);max-height:none!important}
-.faq-item:hover .faq-a{color:rgba(255,255,255,0.88)}
 .partner-badge{display:flex;align-items:center;gap:10px;justify-content:center;margin-bottom:8px}
 .partner-badge img{height:42px;width:auto}
 .partner-badge span{font-weight:900;letter-spacing:.2px}


### PR DESCRIPTION
## Summary
- replace the FAQ markup with button triggers and region ids for screen readers
- add accordion styling for collapsed/expanded states with animated transitions
- wire up JavaScript handlers to toggle items, sync aria attributes, and close siblings

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e2a0cfe580832790a2a98b7dcab659