### PR TITLE
Fix FAQ accordion layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -150,7 +150,7 @@ body{
 .test{background:#fff;padding:18px;border-radius:12px;box-shadow:var(--shadow);font-style:normal}
 
 /* FAQ */
-.faq-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:16px;margin-top:20px}
+.faq-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:16px;margin-top:20px;align-items:start}
 .faq-item{background:rgba(11,11,11,0.85);border-radius:12px;box-shadow:0 18px 44px rgba(0,0,0,0.34);transition:transform .25s ease,box-shadow .25s ease,border-color .25s ease,color .25s ease;border:1px solid rgba(255,255,255,0.08);backdrop-filter:blur(6px);color:rgba(255,255,255,0.88);overflow:hidden}
 .faq-item:hover{transform:translateY(-6px);box-shadow:0 26px 56px rgba(0,0,0,0.46);border-color:rgba(255,255,255,0.18)}
 .faq-head{margin:0}


### PR DESCRIPTION
## Summary
- prevent FAQ grid cells from stretching to the tallest item so each accordion keeps its own height

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e4082bb778832780c6c8cde0a1f6b0